### PR TITLE
Use decouple directly to load env secrets [Closes #156]

### DIFF
--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -198,8 +198,8 @@ Adding secrets to CertHelper
    you follow the directions below.
 
 
-Secrets, in this context, are variables loaded by Django at runtime from `dqmhelper/settings.py
-<https://github.com/CMSTrackerDPG/certifier/blob/master/dqmhelper/settings.py>`__
+Secrets, in this context, are variables loaded by Django at runtime using
+`python-decouple<https://pypi.org/project/python-decouple/>`__
 and they should not be publicly available.
 
 To prevent them being stored in a plain-text file like ``settings.py``, they are
@@ -222,20 +222,9 @@ To create a new secret, follow the steps below:
    name of the secret you created on the previous step (e.g. ``vocms-secrets``) and
    the key of the secret you want to use (e.g. ``username``).
    Give the new environmental variable a meaningful name, e.g. ``VOCMS_USERNAME``.
-
-3. By now, the secret is safely stored inside PaaS, but we still need to load it
-   to Django. **You will have to make a commit to the CertHelper repository for this**.
-   Pull the latest code from GitHub and edit ``dqmhelper/settings.py``, adding a new line
-   which loads the environmental variable into a python variable.
-
-   .. code:: python
-
-	  VOCMS_USERNAME = config("VOCMS_USERNAME")
-
-   This will load the ``VOCMS_USERNAME`` environmental variable into
-   a python variable also named ``VOCMS_USERNAME``.
+   The secret is now ready to be used.
    
-4. You will have to rebuild the project for this. See :doc:`deployment`.
+3. You will have to rebuild the project now. See :doc:`deployment`.
    The secret is now safely available in CertHelper.
 
 			 

--- a/remotescripts/models.py
+++ b/remotescripts/models.py
@@ -5,6 +5,7 @@ import logging
 from abc import abstractclassmethod
 import subprocess
 import paramiko
+from decouple import config
 from django.db import models
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
@@ -206,8 +207,8 @@ class RemoteScriptConfiguration(ScriptConfigurationBase):
         try:
             ssh.connect(
                 self.host,
-                username=getattr(settings, self.env_secret_username),
-                password=getattr(settings, self.env_secret_password),
+                username=config(self.env_secret_username),
+                password=config(self.env_secret_password),
                 port=self.port,
             )
             self.on_connect_success(self.host)


### PR DESCRIPTION
Secrets in `remotescripts` were initially loaded from `django.conf.settings` which required
that the `settings.py` should be altered for each new secret. 

Instead, `decouple` can be used directly once the environment secret is available in the build.  