### PR TITLE
Different channel groups for each remotescript execution and other enhancements[Closes #154]

### DIFF
--- a/dqmhelper/asgi.py
+++ b/dqmhelper/asgi.py
@@ -9,8 +9,24 @@ https://docs.djangoproject.com/en/3.0/howto/deployment/asgi/
 
 import os
 from .wsgi import *
-from channels.routing import get_default_application
+
+from channels.routing import ProtocolTypeRouter
+from django.core.asgi import get_asgi_application
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+import remotescripts.routing
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dqmhelper.settings")
 
-application = get_default_application()
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "https": django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            AuthMiddlewareStack(URLRouter(remotescripts.routing.websocket_urlpatterns))
+        ),
+    }
+)

--- a/dqmhelper/settings.py
+++ b/dqmhelper/settings.py
@@ -124,7 +124,7 @@ AUTHENTICATION_BACKENDS = (
 LOGIN_REDIRECT_URL = "/"
 
 # WSGI_APPLICATION = "dqmhelper.wsgi.application"
-ASGI_APPLICATION = "dqmhelper.routing.application"
+ASGI_APPLICATION = "dqmhelper.asgi.application"
 
 CHANNEL_LAYERS = {
     "default": {

--- a/remotescripts/consumers.py
+++ b/remotescripts/consumers.py
@@ -1,0 +1,42 @@
+import logging
+import json
+from asgiref.sync import async_to_sync
+from channels.generic.websocket import WebsocketConsumer
+
+logger = logging.getLogger(__name__)
+
+
+class ScriptOutputConsumer(WebsocketConsumer):
+    def connect(self):
+        self.script_id = self.scope["url_route"]["kwargs"]["script_id"]
+        self.group_name = f"output_{self.script_id}"
+
+        # Join group
+        async_to_sync(self.channel_layer.group_add)(self.group_name, self.channel_name)
+
+        self.accept()
+        logger.debug(f"Client {self.channel_name} connected to {self.group_name}")
+
+    def disconnect(self, close_code):
+        # Leave group
+        async_to_sync(self.channel_layer.group_discard)(
+            self.group_name, self.channel_name
+        )
+        logger.debug(f"Client {self.channel_name} disconnected from {self.group_name}")
+
+    # # Receive message from WebSocket
+    # def receive(self, text_data):
+    #     text_data_json = json.loads(text_data)
+    #     message = text_data_json["message"]
+
+    #     # Send message to room group
+    #     async_to_sync(self.channel_layer.group_send)(
+    #         self.group_name, {"type": "chat_message", "message": message}
+    #     )
+
+    # Receive message from group
+    def script_output(self, event):
+        message = event["message"]
+
+        # Send message to WebSocket
+        self.send(text_data=json.dumps({"message": message}))

--- a/remotescripts/consumers.py
+++ b/remotescripts/consumers.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 class ScriptOutputConsumer(WebsocketConsumer):
     def connect(self):
+        """Runs on websocket connected"""
         self.script_id = self.scope["url_route"]["kwargs"]["script_id"]
         self.group_name = f"output_{self.script_id}"
 
@@ -17,8 +18,8 @@ class ScriptOutputConsumer(WebsocketConsumer):
         self.accept()
         logger.debug(f"Client {self.channel_name} connected to {self.group_name}")
 
-    def disconnect(self, close_code):
-        # Leave group
+    def disconnect(self, code):
+        """Leave group"""
         async_to_sync(self.channel_layer.group_discard)(
             self.group_name, self.channel_name
         )
@@ -34,8 +35,8 @@ class ScriptOutputConsumer(WebsocketConsumer):
     #         self.group_name, {"type": "chat_message", "message": message}
     #     )
 
-    # Receive message from group
     def script_output(self, event):
+        """Receive message from group"""
         message = event["message"]
 
         # Send message to WebSocket

--- a/remotescripts/output_socket.py
+++ b/remotescripts/output_socket.py
@@ -14,7 +14,7 @@ class OutputSocket(WebsocketConsumer):
         )
 
     # Receive message from the group
-    def channel_message(self, event):
+    def script_output(self, event):
         message = event["message"]
 
         # Send message to WebSocket

--- a/remotescripts/output_socket.py
+++ b/remotescripts/output_socket.py
@@ -2,19 +2,20 @@ from channels.generic.websocket import WebsocketConsumer
 from asgiref.sync import async_to_sync
 import json
 
+
 class OutputSocket(WebsocketConsumer):
     def connect(self):
         self.accept()
         async_to_sync(self.channel_layer.group_add)("output_group", self.channel_name)
 
     def disconnect(self, close_code):
-        async_to_sync(self.channel_layer.group_discard)("output_group", self.channel_name)
+        async_to_sync(self.channel_layer.group_discard)(
+            "output_group", self.channel_name
+        )
 
     # Receive message from the group
     def channel_message(self, event):
-        message = event['message']
+        message = event["message"]
 
         # Send message to WebSocket
-        self.send(text_data=json.dumps({
-            'message': message
-        }))
+        self.send(text_data=json.dumps({"message": message}))

--- a/remotescripts/routing.py
+++ b/remotescripts/routing.py
@@ -1,7 +1,11 @@
-from django.urls import path
+from django.urls import path, re_path
 
-from . import output_socket
+from . import output_socket, consumers
 
 websocket_urlpatterns = [
-    path('ws/output/', output_socket.OutputSocket.as_asgi()),
+    path("ws/output/", output_socket.OutputSocket.as_asgi()),
+    re_path(
+        r"ws/remotescripts/(?P<script_id>\d+)/$",
+        consumers.ScriptOutputConsumer.as_asgi(),
+    ),
 ]

--- a/remotescripts/templates/remotescripts/remote.html
+++ b/remotescripts/templates/remotescripts/remote.html
@@ -63,43 +63,43 @@
  function clearOutput(){
 	 $('#id_command_output').val("");
  };
-
+ 
  $(document).ready(function() {	 
 	 // WS initialization
 	 if (location.protocol === 'https:') {
 		 // page is secure
 		 var command_output_socket = new WebSocket(
 			 'wss://' + window.location.host +
-			 '/ws/output/');
-		 }
-		 else{
-			 var command_output_socket = new WebSocket(
-				 'ws://' + window.location.host +
-				 '/ws/output/');
-		 }
+			 '/ws/remotescripts/{{remote_script.pk}}/' );
+	 }
+	 else{
+		 var command_output_socket = new WebSocket(
+			 'ws://' + window.location.host +
+			 '/ws/remotescripts/{{remote_script.pk}}/');
+	 }
 
 
-		 // Callback run on every new message that
-		 // is received from the WS
-		 command_output_socket.onmessage = function(e) {
-			 var data = JSON.parse(e.data);
-			 if(typeof data['message'] === 'object'){
-				 for(var key of Object.keys(data['message'])){
-					 if (key.startsWith('file'))
-					 {
-						 var file_id = Number(key.substring(key.indexOf('file') + 4));
-						 img_div = document.getElementById(`output-img-${file_id}`);
-						 img_div.src = `data:image/png;base64,${data['message'][key]}`
-					 }
+	 // Callback run on every new message that
+	 // is received from the WS
+	 command_output_socket.onmessage = function(e) {
+		 var data = JSON.parse(e.data);
+		 if(typeof data['message'] === 'object'){
+			 for(var key of Object.keys(data['message'])){
+				 if (key.startsWith('file'))
+				 {
+					 var file_id = Number(key.substring(key.indexOf('file') + 4));
+					 img_div = document.getElementById(`output-img-${file_id}`);
+					 img_div.src = `data:image/png;base64,${data['message'][key]}`
 				 }
 			 }
-			 else
-			 {
-				 var message = data['message'];
-				 document.querySelector('#id_command_output').value += (message);
-				 document.getElementById('id_command_output').scrollTop = document.getElementById('id_command_output').scrollHeight;
-			 }
-		 };
+		 }
+		 else
+		 {
+			 var message = data['message'];
+			 document.querySelector('#id_command_output').value += (message);
+			 document.getElementById('id_command_output').scrollTop = document.getElementById('id_command_output').scrollHeight;
+		 }
+	 };
 
 				 command_output_socket.onclose = function(e) {
 			 console.error('Socket closed unexpectedly: '+ e.message);

--- a/remotescripts/templates/remotescripts/remote.html
+++ b/remotescripts/templates/remotescripts/remote.html
@@ -83,22 +83,25 @@
 	 // is received from the WS
 	 command_output_socket.onmessage = function(e) {
 		 var data = JSON.parse(e.data);
-		 if(typeof data['message'] === 'object'){
-			 for(var key of Object.keys(data['message'])){
-				 if (key.startsWith('file'))
-				 {
-					 var file_id = Number(key.substring(key.indexOf('file') + 4));
-					 img_div = document.getElementById(`output-img-${file_id}`);
-					 img_div.src = `data:image/png;base64,${data['message'][key]}`
-				 }
+		 
+		 for(var key of Object.keys(data['message'])){
+			 if (key.startsWith('file'))
+			 {
+				 var file_id = Number(key.substring(key.indexOf('file') + 4));
+				 img_div = document.getElementById(`output-img-${file_id}`);
+				 img_div.src = `data:image/png;base64,${data['message'][key]}`
+			 }
+			 else if (key.startsWith('stdout')){
+				 var message = data['message']['stdout'];
+				 document.querySelector('#id_command_output').value += (message);
+				 document.getElementById('id_command_output').scrollTop = document.getElementById('id_command_output').scrollHeight;
+			 }
+			 else if (key.startsWith('status'))
+			 {
+				 // console.log(data['message']['status']);
 			 }
 		 }
-		 else
-		 {
-			 var message = data['message'];
-			 document.querySelector('#id_command_output').value += (message);
-			 document.getElementById('id_command_output').scrollTop = document.getElementById('id_command_output').scrollHeight;
-		 }
+
 	 };
 
 				 command_output_socket.onclose = function(e) {

--- a/remotescripts/templates/remotescripts/remote.html
+++ b/remotescripts/templates/remotescripts/remote.html
@@ -32,7 +32,11 @@
 						id="remote_script_execution_form" >
 				{% csrf_token %}
 				{{ form }}
-				<input type="submit" value="Submit">
+				<input type="submit"
+					   value="Submit"
+					   id="form_submit"
+					   title="Execute the script"
+					   class="btn btn-primary">
 			</form>
         </div>
     </div>
@@ -63,6 +67,18 @@
  function clearOutput(){
 	 $('#id_command_output').val("");
  };
+ 
+// Prevent buttons from being clicked while script is running
+ function disableControls(){
+	 $('#form_submit').prop('disabled', true)
+					  .prop('title', "Wait for script execution to finish");
+ }
+ 
+ // Reenable buttons once script ends
+ function enableControls(){
+	 $('#form_submit').prop('disabled', false)
+					  .prop('title', "Execute the script");
+ }
  
  $(document).ready(function() {	 
 	 // WS initialization
@@ -99,54 +115,59 @@
 			 else if (key.startsWith('status'))
 			 {
 				 // console.log(data['message']['status']);
+				 var status = data['message']['status'];
+				 if(status === 'script_start'){
+					 disableControls();
+				 }
+				 else if(status.startsWith('script_end')){
+					 enableControls();
+				 }
 			 }
 		 }
-
 	 };
+	 command_output_socket.onclose = function(e) {
+		 console.error('Socket closed unexpectedly: '+ e.message);
+	 };
+ })
 
-				 command_output_socket.onclose = function(e) {
-			 console.error('Socket closed unexpectedly: '+ e.message);
-		 };
-	 })
+ var btn_clear = document.getElementById('btn-clear');
+ btn_clear.onclick = clearOutput;
 
-	 var btn_clear = document.getElementById('btn-clear');
-	 btn_clear.onclick = clearOutput;
-
-	 var $myForm = $("#remote_script_execution_form");
-	 $myForm.on('submit', function(ev){
-		 $("#remote_script_execution_form").find(':input[type=submit]').prop('disabled', true);
-		 // add spinner to button
-		 // if ($('[id=id_run_number]').val() != '') {
-		 // 			 $('#id_run_number_list').removeAttr('required');
-		 // 		 }
-		 // if ($("#id_form_generate_maps")[0].checkValidity()) {
-		 // 			 $("#id_generate_maps").html(
-		 // 				 `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`
-		 // 			 );
-		 // 		 }
-		 var $inputs = $('#remote_script_execution_form :input');
-		 var values = {};
-		 $inputs.each(function() {
-			 if(this.name !== ""){
-				 values[this.name] = $(this).val();
-			 }
-		 });
-		 $.ajax({
-			 headers: { "X-CSRFToken": '{{csrf_token}}' },
-			 type: "POST",
-			 // url: "",// Not needed
-			 data: values,
-		 })
-		  .always(function(){
-		  })
-		  .fail(function(data){
-			  let msg = `Command failed with error ${data.status}: ${JSON.parse(data.responseText).message}`;
-			  console.error(msg);
-			  alert(msg);
-		  });
-		 ev.preventDefault();
-		 return false;
+ var $myForm = $("#remote_script_execution_form");
+ $myForm.on('submit', function(ev){
+	 $("#remote_script_execution_form").find(':input[type=submit]').prop('disabled', true);
+	 // add spinner to button
+	 // if ($('[id=id_run_number]').val() != '') {
+	 // 			 $('#id_run_number_list').removeAttr('required');
+	 // 		 }
+	 // if ($("#id_form_generate_maps")[0].checkValidity()) {
+	 // 			 $("#id_generate_maps").html(
+	 // 				 `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`
+	 // 			 );
+	 // 		 }
+	 var $inputs = $('#remote_script_execution_form :input');
+	 var values = {};
+	 $inputs.each(function() {
+		 if(this.name !== ""){
+			 values[this.name] = $(this).val();
+		 }
 	 });
-	 
-	</script>
+	 $.ajax({
+		 headers: { "X-CSRFToken": '{{csrf_token}}' },
+		 type: "POST",
+		 // url: "",// Not needed
+		 data: values,
+	 })
+	  .always(function(){
+	  })
+	  .fail(function(data){
+		  let msg = `Command failed with error ${data.status}: ${JSON.parse(data.responseText).message}`;
+		  console.error(msg);
+		  alert(msg);
+	  });
+	 ev.preventDefault();
+	 return false;
+ });
+ 
+</script>
 {% endblock %}

--- a/remotescripts/views.py
+++ b/remotescripts/views.py
@@ -59,7 +59,7 @@ class ScriptExecutionBaseView(LoginRequiredMixin, UserPassesTestMixin, DetailVie
         Function that sends a message
         """
         async_to_sync(channel_layer.group_send)(
-            group_name, {"type": "channel_message", "message": message}
+            group_name, {"type": "script.output", "message": message}
         )
 
 
@@ -95,27 +95,27 @@ class RemoteScriptView(ScriptExecutionBaseView):
             args = []
             kwargs = {
                 "on_new_output_line": lambda msg: self.send_channel_message(
-                    channel_layer, "output_group", msg
+                    channel_layer, f"output_{pk}", msg
                 ),
                 "on_connect_failure": lambda msg: self.send_channel_message(
-                    channel_layer, "output_group", msg
+                    channel_layer, f"output_{pk}", msg
                 ),
                 "on_connect_success": lambda host: self.send_channel_message(
                     channel_layer,
-                    "output_group",
+                    f"output_{pk}",
                     f"-------- CONNECTED TO {host} --------\n",
                 ),
                 "on_script_start": lambda: self.send_channel_message(
-                    channel_layer, "output_group", "-------- SCRIPT STARTED --------\n"
+                    channel_layer, f"output_{pk}", "-------- SCRIPT STARTED --------\n"
                 ),
                 "on_script_end": lambda exit_status: self.send_channel_message(
                     channel_layer,
-                    "output_group",
+                    f"output_{pk}",
                     f"-------- SCRIPT STOPPED (exit status: {exit_status}) --------\n",
                 ),
                 "on_new_output_file": lambda file_id, filepath: self.send_channel_message(
                     channel_layer,
-                    "output_group",
+                    f"output_{pk}",
                     {
                         f"file{file_id}": self._encode_file_base64(filepath).decode(
                             "ascii"

--- a/remotescripts/views.py
+++ b/remotescripts/views.py
@@ -90,7 +90,7 @@ class RemoteScriptView(ScriptExecutionBaseView):
         form = ScriptExecutionForm(instance=instance, data=request.POST)
 
         if form.is_valid():
-            self.send_channel_message(channel_name, {"status": "script_started"})
+            self.send_channel_message(channel_name, {"status": "script_start"})
             args = []
             kwargs = {
                 "on_new_output_line": lambda msg: self.send_channel_message(
@@ -113,7 +113,9 @@ class RemoteScriptView(ScriptExecutionBaseView):
                     channel_name,
                     {
                         "stdout": f"-------- SCRIPT STOPPED (exit status: {exit_status}) --------\n",
-                        "status": "script_fail" if exit_status else "script_success",
+                        "status": "script_end_fail"
+                        if exit_status
+                        else "script_end_success",
                     },
                 ),
                 "on_new_output_file": lambda file_id, filepath: self.send_channel_message(


### PR DESCRIPTION
- Used different channel groups so that each remotescript's `stdout` is channeled only to similar script websockets
- Refactored messages passed on to websockets to include more information such as script status
- Disable controls for all connected users while script is running. Re-enable them on script end