### PR TITLE
New exception, Allow editing OMS info

### DIFF
--- a/certifier/templates/certifier/certify.html
+++ b/certifier/templates/certifier/certify.html
@@ -78,7 +78,19 @@
             <div class="col-md-4">
                 <div class="card shadow-sm bg-white">
                     <div class="card-body">
-                        <h6 class="card-title text-primary">Type</h6>
+                        <div class="row">
+                            <div class="col-11">
+                                <h6 class="card-title text-primary">Type</h6>
+                            </div>
+                            <div class="col-1">
+                                {% comment %} Allow editing of OMS attributes {% endcomment %}
+                                {% if form.external_info_complete.value %}
+                                <div class="row justify-content-center">
+                                    <a class="btn btn-light" title="Edit OMS info" href="./?external_info_complete=false"><i class="bi bi-pencil-fill pl-1"></i></a>
+                                </div>
+                                {% endif %}
+                            </div>
+                        </div>
                         <div class="row m-1">
                             <div class="col-md-4 text-right">
                                 <strong>Run type</strong>
@@ -155,8 +167,19 @@
             <div class="col-md-4">
                 <div class="card shadow-sm">
                     <div class="card-body">
-
-                        <h6 class="card-title text-success">Lumi</h6>
+                        <div class="row">
+                            <div class="col-11">
+                                <h6 class="card-title text-success">Lumi</h6>
+                            </div>
+                            <div class="col-1">
+                                {% comment %} Allow editing of OMS attributes {% endcomment %}
+                                {% if form.external_info_complete.value %}
+                                <div class="row justify-content-center">
+                                    <a class="btn btn-light" title="Edit OMS info" href="./?external_info_complete=false"><i class="bi bi-pencil-fill pl-1"></i></a>
+                                </div>
+                                {% endif %}
+                            </div>
+                        </div>
                         <div class="row m-1">
                             <div class="col-md-5 text-right">
                                 <strong>Lumisections</strong>
@@ -237,7 +260,19 @@
             <div class="col-md-4">
                 <div class="card shadow-sm">
                     <div class="card-body">
-                        <h6 class="card-title text-info">Fill</h6>
+                        <div class="row">
+                            <div class="col-11">
+                                <h6 class="card-title text-info">Fill</h6>
+                            </div>
+                            <div class="col-1">
+                                {% comment %} Allow editing of OMS attributes {% endcomment %}
+                                {% if form.external_info_complete.value %}
+                                <div class="row justify-content-center">
+                                    <a class="btn btn-light" title="Edit OMS info" href="./?external_info_complete=false"><i class="bi bi-pencil-fill pl-1"></i></a>
+                                </div>
+                                {% endif %}
+                            </div>
+                        </div>
                         <div class="row m-1">
                             <div class="col-md-5 text-right">
                                 <strong>Fill number</strong>

--- a/certifier/views.py
+++ b/certifier/views.py
@@ -24,6 +24,7 @@ from oms.models import OmsRun, OmsFill
 from oms.exceptions import (
     OmsApiFillNumberNotFound,
     OmsApiRunNumberNotFound,
+    OmsApiDataInvalidError,
     RunRegistryNoAvailableDatasets,
     RunRegistryReconstructionNotFound,
 )
@@ -204,6 +205,7 @@ class CertifyView(View):
             ParseError,
             OmsApiRunNumberNotFound,
             OmsApiFillNumberNotFound,
+            OmsApiDataInvalidError,
         ) as e:
             # If OMS API does not contain the info required,
             # or OMS is unreachable, create the run with minimal
@@ -222,6 +224,10 @@ class CertifyView(View):
         logger.debug(
             f"Requesting certification of run {run_number} {reco if reco else ''}"
         )
+        # Allow GUI user to force update of the OMS data
+        # A bit of a machete code, in order to
+        if request.GET.get("external_info_complete", None) == "false":
+            self.external_info_complete = False
 
         context = {
             "run_number": run_number,

--- a/dqmhelper/settings.py
+++ b/dqmhelper/settings.py
@@ -20,7 +20,7 @@ MESSAGE_TAGS = {
     messages.ERROR: "danger",
 }
 # Version to display in order to keep track of changes
-CERTHELPER_VERSION = "1.10.3"
+CERTHELPER_VERSION = "1.11.0"
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/oms/exceptions.py
+++ b/oms/exceptions.py
@@ -10,6 +10,13 @@ class OmsApiRunNumberNotFound(Exception):
     """
 
 
+class OmsApiDataInvalidError(Exception):
+    """
+    Raised when data from OMS violates a constraint in our DB,
+    e.g. Colliding bunches < 0
+    """
+
+
 class RunRegistryNoAvailableDatasets(Exception):
     """
     Raised when no datasets were found in RunRegistry


### PR DESCRIPTION

Handle IntegrityErrors more ""flexibly"" by checking the actual error string. Related to #242.

Also add buttons to edit OMS info in the certify form.
