### PR TITLE
Use OIDC SSO provider instead of deprecated cern one

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -42,17 +42,8 @@ jobs:
         git config --global url."https://${{ secrets.CERN_GITLAB_USER }}:${{ secrets.CERN_GITLAB_TOKEN }}@gitlab.cern.ch".insteadOf https://gitlab.cern.ch
         python -m pip install --upgrade pip
         
-        ALLAUTH_INSTALL_DIR=$HOME
-        mkdir -p $ALLAUTH_INSTALL_DIR
-        git clone https://github.com/nothingface0/django-allauth.git $ALLAUTH_INSTALL_DIR/django-allauth
-        cd $ALLAUTH_INSTALL_DIR/django-allauth
-        git checkout 77368a8
-        wget https://github.com/pennersr/django-allauth/compare/main...nothingface0:django-allauth:fix_cern_sso.patch --output-document=patch
-        git apply patch --reject || true
-        cd -
-        
         pip install -r requirements.txt
-        pip install $ALLAUTH_INSTALL_DIR/django-allauth
+
         pip install --index-url https://test.pypi.org/simple runregistry==1.0.0
 
         pip install --upgrade pytest pytest-django pytest-cov codecov mixer selenium
@@ -69,7 +60,8 @@ jobs:
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
         OMS_CLIENT_ID: ${{ secrets.OMS_CLIENT_ID }}
         OMS_CLIENT_SECRET: ${{ secrets.OMS_CLIENT_SECRET }}
-
+        CERN_SSO_REGISTRATION_CLIENT_ID: ${{ secrets.CERN_SSO_REGISTRATION_CLIENT_ID }}
+        CERN_SSO_REGISTRATION_CLIENT_SECRET: ${{ secrets.CERN_SSO_REGISTRATION_CLIENT_SECRET }}
       run: |
         PYTHONWARNINGS=all pytest --ds=dqmhelper.test_ci_settings --cov=./ --ignore addrefrun/tests/test_addrefrun_views.py --ignore certifier/tests/test_certifier_views.py --ignore oms/tests/test_oms_utils.py --ignore oms/tests/test_oms_models.py
         codecov

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,22 +1,8 @@
 #!/bin/bash
 echo "Before assembling"
 git config --global url."https://$CERN_GITLAB_USER:$CERN_GITLAB_TOKEN@gitlab.cern.ch".insteadOf https://gitlab.cern.ch   
-
-# TODO: remove once PR in django-allauth merged
-ALLAUTH_INSTALL_DIR=$HOME
-mkdir -p $ALLAUTH_INSTALL_DIR
-git clone https://github.com/nothingface0/django-allauth.git $ALLAUTH_INSTALL_DIR/django-allauth
-cd $ALLAUTH_INSTALL_DIR/django-allauth
-git checkout 77368a8
-wget https://github.com/pennersr/django-allauth/compare/main...nothingface0:django-allauth:fix_cern_sso.patch --output-document=patch
-git apply patch --reject || true
-cd -
-
-
 /usr/libexec/s2i/assemble
 rc=$?
-
-pip install $ALLAUTH_INSTALL_DIR/django-allauth
 
 # Temporarily install runregistry api client from test PyPI
 pip install --index-url https://test.pypi.org/simple runregistry==1.0.0

--- a/dqmhelper/settings.py
+++ b/dqmhelper/settings.py
@@ -10,9 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
-import os
 from pathlib import Path
-
 from decouple import config
 from django.contrib.messages import constants as messages
 
@@ -76,7 +74,7 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
-    "allauth.socialaccount.providers.cern",
+    "allauth.socialaccount.providers.openid_connect",
     "widget_tweaks",
     "django_extensions",
     "django_tables2",
@@ -227,3 +225,34 @@ CERN_CERTIFICATE_PATH = config("CERN_CERTIFICATE_PATH", default="")
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 ACCOUNT_EMAIL_VERIFICATION = "none"
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+
+SOCIALACCOUNT_PROVIDERS = {
+    "openid_connect": {
+        "SERVERS": [
+            {
+                "id": "cern",  # 30 characters or less
+                "name": "CERN",
+                "server_url": "https://auth.cern.ch/auth/realms/cern",
+                # Optional token endpoint authentication method.
+                # May be one of "client_secret_basic", "client_secret_post"
+                # If omitted, a method from the the server's
+                # token auth methods list is used
+                "token_auth_method": "client_secret_post",
+                "APP": {
+                    "client_id": config("CERN_SSO_REGISTRATION_CLIENT_ID"),
+                    "secret": config("CERN_SSO_REGISTRATION_CLIENT_SECRET"),
+                },
+            },
+        ]
+    }
+}
+
+# This is used to get the public key and decode access tokens
+# for users when they login. The URL can be found under the
+# jwks_uri key of the JSON pointed to by the server_url of
+# CERN's well-known config URL:
+# https://auth.cern.ch/auth/realms/cern/.well-known/openid-configuration
+CERN_SSO_JWKS_URI = (
+    "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/certs"
+)

--- a/dqmhelper/test_settings.py
+++ b/dqmhelper/test_settings.py
@@ -1,3 +1,4 @@
+import os
 from .settings import *
 
 if os.environ.get("GITHUB_WORKFLOW"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,7 @@ certifi<2023.0.0
 channels[daphne]
 channels_redis
 Django<4.2.0
-# TODO: Update this once PR is merged to django-allauth
-#-e /home/runner/django-allauth
-#django-allauth<1.0.0
+django-allauth<1.0.0
 django-bootstrap3<24.0
 django-filter<24.0
 django-ckeditor<7.0.0
@@ -29,5 +27,6 @@ apscheduler
 whitenoise
 factory_boy
 prettytable
+pyjwt
 git+https://gitlab.cern.ch/cmsoms/oms-api-client
 git+https://github.com/eea/odfpy.git

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,22 +1,29 @@
-import allauth
+import jwt
 import django
+import allauth
 from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialAccount
-from allauth.socialaccount.signals import social_account_updated, \
-    social_account_added, social_account_removed, pre_social_login
+from allauth.socialaccount.signals import (
+    social_account_updated,
+    social_account_added,
+    social_account_removed,
+    pre_social_login,
+)
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
 from users.utilities.logger import get_configured_logger
 from users.utilities.utilities import update_user_extradata
+from decouple import config
+from django.conf import settings
 
 logger = get_configured_logger(loggername=__name__, filename="signals.log")
+
 
 @receiver(django.contrib.auth.signals.user_logged_in)
 def update_users_on_login(sender, user, request, **kwargs):
     update_user_extradata(user)
-    user.save()
 
 
 @receiver(pre_save, sender=get_user_model())
@@ -40,19 +47,35 @@ def log_user_logged_out(sender, user, request, **kwargs):
     logger.info("User {} has logged out".format(user))
 
 
-@receiver(pre_social_login)
-def log_pre_social_login(request, sociallogin, **kwargs):
+def log_pre_social_login(request, sociallogin):
     try:
         logger.debug("Pre social login for User {}".format(sociallogin.user))
     except (get_user_model().DoesNotExist, AttributeError):
         logger.debug("Pre social login for non-existing User")
 
 
+@receiver(pre_social_login)
+def pre_social_login(request, sociallogin, **kwargs):
+    # Get the token from the login and decode it,
+    # so that we can get cern_roles out of it
+    key = jwt.PyJWKClient(settings.CERN_SSO_JWKS_URI).get_signing_keys()[0]
+    sociallogin.account.extra_data = jwt.decode(
+        jwt=sociallogin.token.token.encode("utf-8"),
+        key=key.key,
+        algorithms=["RS256"],
+        audience=config("CERN_SSO_REGISTRATION_CLIENT_ID"),
+    )
+    log_pre_social_login(request, sociallogin=sociallogin)
+
+
 @receiver(social_account_added)
 def log_social_account_added(request, sociallogin, **kwargs):
     try:
-        logger.info("Social Account {} has been added for User {}"
-                    .format(sociallogin.account, sociallogin.user))
+        logger.info(
+            "Social Account {} has been added for User {}".format(
+                sociallogin.account, sociallogin.user
+            )
+        )
     except (SocialAccount.DoesNotExist, get_user_model().DoesNotExist, AttributeError):
         logger.debug("Pre social login for non-existing User")
 
@@ -60,8 +83,11 @@ def log_social_account_added(request, sociallogin, **kwargs):
 @receiver(social_account_updated)
 def log_social_account_updated(request, sociallogin, **kwargs):
     try:
-        logger.debug("Social Account {} has been updated for User {}"
-                     .format(sociallogin.account, sociallogin.user))
+        logger.debug(
+            "Social Account {} has been updated for User {}".format(
+                sociallogin.account, sociallogin.user
+            )
+        )
     except (SocialAccount.DoesNotExist, get_user_model().DoesNotExist, AttributeError):
         logger.error("Something unexpected happened")
 
@@ -69,8 +95,11 @@ def log_social_account_updated(request, sociallogin, **kwargs):
 @receiver(social_account_removed)
 def log_social_account_removed(request, socialaccount, **kwargs):
     try:
-        logger.info("Social Account {} has been removed from User {}"
-                    .format(socialaccount, socialaccount.user))
+        logger.info(
+            "Social Account {} has been removed from User {}".format(
+                socialaccount, socialaccount.user
+            )
+        )
     except (get_user_model().DoesNotExist, AttributeError):
         logger.error("Something unexpected happened")
 
@@ -79,6 +108,7 @@ def log_social_account_removed(request, socialaccount, **kwargs):
 def log_user_has_login_failed(sender, credentials, request, **kwargs):
     try:
         logger.warning(
-            "User {} has failed to logged in".format(credentials.get("username")))
+            "User {} has failed to logged in".format(credentials.get("username"))
+        )
     except AttributeError:
         logger.error("Username attribute does not exist!")

--- a/users/tests/test_users_signals.py
+++ b/users/tests/test_users_signals.py
@@ -1,9 +1,9 @@
 import pytest
 from django.db import IntegrityError
-from mixer.backend.django import mixer
 from django.contrib.auth import get_user_model
-from users.signals import *
 from django.test import Client
+from users.signals import *
+from mixer.backend.django import mixer
 
 pytestmark = pytest.mark.django_db
 
@@ -12,6 +12,12 @@ def test_create_user():
     user = mixer.blend(get_user_model())
     user.extra_data = {"hi": "test"}
     assert user
+
+
+def test_pre_social_login():
+    # TODO: Add test for verifying functionality
+    # of users.signals.pre_social_login, if possible
+    pass
 
 
 def test_logs():


### PR DESCRIPTION
Updating `django-allauth` config to use the new SSO which is OIDC-based. There was no need to update the `cern` provider in `django-allauth`, as the `openid_connect` adapter works just fine. 

Extra steps that have to be done after deploying:

1. "Migrate" the existing `SocialAccount` entries as follows:
	1. Run `python manage.py shell`.
	2. Run:
    ```python
    from allauth.socialaccount.models import SocialAccount
    sa = SocialAccount.objects.filter(provider="cern")
	for s in sa:
		if 'username' in s.extra_data:
			s.uid = s.extra_data["username"]
			s.save()
	````
2. Extra env vars that need to be added:
	1. `CERN_SSO_REGISTRATION_CLIENT_ID`
	2. `CERN_SSO_REGISTRATION_CLIENT_SECRET`