### PR TITLE
Configurable OMS api URL [Closes #240]

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -16,6 +16,8 @@ DJANGO_SECRET_PASS=
 # For connecting to OMS
 OMS_CLIENT_ID=
 OMS_CLIENT_SECRET=
+# OMS_API_URL=https://cmsoms.cern.ch/agg/api
+# OMS_API_AUDIENCE=cmsoms-prod
 
 # For connecting to Run Registry. You can reuse 
 # the OMS_CLIENT_ID and OMS_CLIENT_SECRET

--- a/omsapi/apiconfig.py
+++ b/omsapi/apiconfig.py
@@ -1,7 +1,9 @@
 from decouple import config
 
-API_URL = 'https://vocms0185.cern.ch/agg/api'
-API_VERSION = 'v1'
-API_AUDIENCE = 'cmsoms-int-0185'
-OMS_CLIENT_ID = config('OMS_CLIENT_ID')
-OMS_CLIENT_SECRET = config('OMS_CLIENT_SECRET')
+# See other options here:
+# https://gitlab.cern.ch/cmsoms/oms-api-client/-/wikis/uploads/01fe5b10560e76849ce636cf53e59e20/OMS_CERN_OpenID_API__2022_.pdf
+API_URL = config("OMS_API_URL", "https://cmsoms.cern.ch/agg/api")
+API_VERSION = "v1"
+API_AUDIENCE = config("OMS_API_AUDIENCE", "cmsoms-prod")
+OMS_CLIENT_ID = config("OMS_CLIENT_ID")
+OMS_CLIENT_SECRET = config("OMS_CLIENT_SECRET")


### PR DESCRIPTION
Make CMS OMS API url configurable, as the "integration" one was being used until now, which is unstable. 

Now uses the production one by default.

More info on OMS API here: https://gitlab.cern.ch/cmsoms/oms-api-client/-/wikis/uploads/01fe5b10560e76849ce636cf53e59e20/OMS_CERN_OpenID_API__2022_.pdf